### PR TITLE
Render embed even on non-standard subdomains

### DIFF
--- a/index.js
+++ b/index.js
@@ -16,7 +16,7 @@ const Timestamp = getModule(m => m.prototype && m.prototype.toDate && m.prototyp
 const isMLEmbed = e => typeof e?.author?.name[1]?.props?.__mlembed !== 'undefined'
 const isVideo = attachment => !!attachment.video || /\.(?:mp4|mov|webm)$/.test(attachment.url)
 
-const re = /https?:\/\/((canary|ptb)\.)?discord(app)?\.com\/channels\/(\d{17,19}|@me)\/\d{17,19}\/\d{17,19}/
+const re = /https?:\/\/([^\s]*\.)?discord(app)?\.com\/channels\/(\d{17,19}|@me)\/\d{17,19}\/\d{17,19}/
 
 module.exports = class MessageLinksEmbed extends Plugin {
     async startPlugin() {

--- a/manifest.json
+++ b/manifest.json
@@ -2,6 +2,6 @@
     "name": "Message Link Embed",
     "description": "Make message links show an embed like invites or store links.",
     "author": "Juby210#0577",
-    "version": "0.1.8",
+    "version": "0.1.9",
     "license": "MIT"
 }


### PR DESCRIPTION
Sometimes people try to be funny and send messages links with an edited subdomain. This PR renders embeds for those too.